### PR TITLE
Update Gulp.md to downgrade Babelify from latest(10.x) to 8.x

### DIFF
--- a/pages/tutorials/Gulp.md
+++ b/pages/tutorials/Gulp.md
@@ -398,7 +398,7 @@ Like Uglify, Babelify mangles code, so we'll need vinyl-buffer and gulp-sourcema
 By default Babelify will only process files with extensions of `.js`, `.es`, `.es6` and `.jsx` so we need to add the `.ts` extension as an option to Babelify.
 
 ```shell
-npm install --save-dev babelify babel-core babel-preset-es2015 vinyl-buffer gulp-sourcemaps
+npm install --save-dev babelify@8 babel-core babel-preset-es2015 vinyl-buffer gulp-sourcemaps
 ```
 
 Now change your gulpfile to the following:


### PR DESCRIPTION
Fixed the instruction to install npm package with using babel 8.x instead of latest version 10.x.

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #920
